### PR TITLE
delete_range() implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
-/target
-/Cargo.lock
+target
+Cargo.lock
+.idea/
+treap-rs.iml

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
-name = "treap"
-version = "0.1.0"
+name = "teardown_tree___treap"
+version = "0.0.1"
 authors = ["Michael Budde <mbudde@gmail.com>"]
 license = "MIT"
 keywords = ["container", "data-structure", "map", "set", "tree"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 
-name = "teardown_tree___treap"
+name = "treap"
 version = "0.0.2"
 authors = ["Michael Budde <mbudde@gmail.com>"]
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "treap"
-version = "0.0.2"
+version = "0.0.3"
 authors = ["Michael Budde <mbudde@gmail.com>"]
 license = "MIT"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,15 +1,14 @@
 [package]
 
 name = "teardown_tree___treap"
-version = "0.0.1"
+version = "0.0.2"
 authors = ["Michael Budde <mbudde@gmail.com>"]
 license = "MIT"
-keywords = ["container", "data-structure", "map", "set", "tree"]
 readme = "README.md"
 homepage = "https://github.com/mbudde/treap-rs"
 repository = "https://github.com/mbudde/treap-rs"
 documentation = "http://mbudde.github.io/treap-rs/treap/index.html"
-description = "Randomized treap implementation"
+description = "Do not use - intended for internal use of teardown_tree crate"
 
 [dependencies]
 rand = "0.3"

--- a/src/map.rs
+++ b/src/map.rs
@@ -2,7 +2,7 @@ use rand;
 
 use std::default::Default;
 use std::iter::{FromIterator, IntoIterator};
-use std::ops::{Index, IndexMut};
+use std::ops::{Index, IndexMut, Range};
 
 use node::{Node};
 
@@ -201,10 +201,10 @@ impl<K: Ord, V, Rng: rand::Rng> TreapMap<K, V, Rng> {
 
 
 impl<K: Ord+Clone, Rng: rand::Rng> TreapMap<K, (), Rng> {
-    pub fn delete_range(&mut self, from: K, to: K, output: &mut Vec<K>) {
+    pub fn remove_range(&mut self, range: Range<K>, output: &mut Vec<K>) {
         let max_prio = ::std::f64::MAX;
         let mut root: Option<Box<Node<K, ()>>> = self.root.take();
-        let res = Node::insert_or_replace(&mut root, Node::new(from.clone(), (), max_prio));
+        let res = Node::insert_or_replace(&mut root, Node::new(range.start.clone(), (), max_prio));
         let mut root = root.unwrap();
 
         let (left, right) = (root.left.take(), root.right.take());
@@ -213,19 +213,19 @@ impl<K: Ord+Clone, Rng: rand::Rng> TreapMap<K, (), Rng> {
         };
 
         let mut root = right;
-        let res = Node::insert_or_replace(&mut root, Node::new(to.clone(), (), max_prio));
+        let res = Node::insert_or_replace(&mut root, Node::new(range.end.clone(), (), max_prio));
         let mut root = root.unwrap();
         let (mid, mut right) = (root.left.take(), root.right.take());
         if res.is_some() {
-            let x = Node::new(to.clone(), (), self.rng.next_f64());
+            let x = Node::new(range.end.clone(), (), self.rng.next_f64());
             Node::insert_or_replace(&mut right, x);
         }
 
-        *root = Node::new(from.clone(), (), max_prio);
+        *root = Node::new(range.start.clone(), (), max_prio);
         root.left = left;
         root.right = right;
         let mut root = Some(root);
-        let res = Node::remove(&mut root, &from);
+        let res = Node::remove(&mut root, &range.start);
         assert!(res.is_some());
 
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -5,7 +5,7 @@ use std::cmp::Ordering;
 pub struct Node<K, V> {
     pub key: K,
     pub value: V,
-    priority: f64,
+    priority: f64, // TODO: use a u64! much faster!
     pub left: Option<Box<Node<K, V>>>,
     pub right: Option<Box<Node<K, V>>>,
 }
@@ -66,7 +66,12 @@ impl<K: Ord, V> Node<K, V> {
 
     pub fn insert(&mut self, node: Node<K, V>) -> Option<V> {
         match node.key.cmp(&self.key) {
-            Ordering::Equal => { Some(mem::replace(&mut self.value, node.value)) }
+            Ordering::Equal => {
+                if self.priority < node.priority {
+                    self.priority = node.priority;
+                }
+                Some(mem::replace(&mut self.value, node.value))
+            }
             Ordering::Less => {
                 let old_value = Node::insert_or_replace(&mut self.left, node);
                 if self.is_heap_property_violated(&self.left) {


### PR DESCRIPTION
This is admittedly very hackish. Primarily, it adds the requirements that K:Clone and V is unit. I implemented it to perform benchmarks against my TeardownTree data structure. So you might want to clean up or improve the code before merging.